### PR TITLE
Utworzenie ekranu logowania i rejestracji

### DIFF
--- a/KinowySystemRezerwacji/KinowySystemRezerwacji.csproj
+++ b/KinowySystemRezerwacji/KinowySystemRezerwacji.csproj
@@ -56,6 +56,12 @@
     <Compile Include="IView.cs" />
     <Compile Include="service\Service.cs" />
     <Compile Include="service\dao\MiejsceRepository.cs" />
+    <Compile Include="view\ExtendedTextBox.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Include="view\ExtendedTextBox.Designer.cs">
+      <DependentUpon>ExtendedTextBox.cs</DependentUpon>
+    </Compile>
     <Compile Include="view\LoginForm.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -91,6 +97,9 @@
     <EmbeddedResource Include="service\DBInfo.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>DBInfo.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Include="view\ExtendedTextBox.resx">
+      <DependentUpon>ExtendedTextBox.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="view\LoginForm.resx">
       <DependentUpon>LoginForm.cs</DependentUpon>

--- a/KinowySystemRezerwacji/KinowySystemRezerwacji.csproj
+++ b/KinowySystemRezerwacji/KinowySystemRezerwacji.csproj
@@ -35,6 +35,7 @@
   <ItemGroup>
     <Reference Include="MySql.Data, Version=8.0.16.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d, processorArchitecture=MSIL" />
     <Reference Include="System" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/KinowySystemRezerwacji/view/ExtendedTextBox.Designer.cs
+++ b/KinowySystemRezerwacji/view/ExtendedTextBox.Designer.cs
@@ -55,7 +55,6 @@
             this.Controls.Add(this.textBox1);
             this.Name = "ExtendedTextBox";
             this.Size = new System.Drawing.Size(314, 35);
-            this.Load += new System.EventHandler(this.ExtendedTextBox_Load);
             this.Enter += new System.EventHandler(this.ExtendedTextBox_Enter);
             this.Leave += new System.EventHandler(this.ExtendedTextBox_Leave);
             ((System.ComponentModel.ISupportInitialize)(this.errorProvider1)).EndInit();

--- a/KinowySystemRezerwacji/view/ExtendedTextBox.Designer.cs
+++ b/KinowySystemRezerwacji/view/ExtendedTextBox.Designer.cs
@@ -1,0 +1,72 @@
+﻿namespace KinowySystemRezerwacji.view
+{
+    partial class ExtendedTextBox
+    {
+        /// <summary> 
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary> 
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        /// <summary> 
+        /// Required method for Designer support - do not modify 
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.components = new System.ComponentModel.Container();
+            this.textBox1 = new System.Windows.Forms.TextBox();
+            this.errorProvider1 = new System.Windows.Forms.ErrorProvider(this.components);
+            ((System.ComponentModel.ISupportInitialize)(this.errorProvider1)).BeginInit();
+            this.SuspendLayout();
+            // 
+            // textBox1
+            // 
+            this.textBox1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.textBox1.Font = new System.Drawing.Font("Microsoft Sans Serif", 14.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(238)));
+            this.textBox1.Location = new System.Drawing.Point(32, 3);
+            this.textBox1.Name = "textBox1";
+            this.textBox1.Size = new System.Drawing.Size(250, 29);
+            this.textBox1.TabIndex = 0;
+            // 
+            // errorProvider1
+            // 
+            this.errorProvider1.ContainerControl = this;
+            // 
+            // ExtendedTextBox
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.textBox1);
+            this.Name = "ExtendedTextBox";
+            this.Size = new System.Drawing.Size(314, 35);
+            this.Load += new System.EventHandler(this.ExtendedTextBox_Load);
+            this.Enter += new System.EventHandler(this.ExtendedTextBox_Enter);
+            this.Leave += new System.EventHandler(this.ExtendedTextBox_Leave);
+            ((System.ComponentModel.ISupportInitialize)(this.errorProvider1)).EndInit();
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.TextBox textBox1;
+        private System.Windows.Forms.ErrorProvider errorProvider1;
+    }
+}

--- a/KinowySystemRezerwacji/view/ExtendedTextBox.cs
+++ b/KinowySystemRezerwacji/view/ExtendedTextBox.cs
@@ -15,11 +15,8 @@ namespace KinowySystemRezerwacji.view
     /// </summary>
     internal partial class ExtendedTextBox : UserControl
     {
-        private bool shouldBeMasked = false;
-        private string placeHolder;
-        private string errorMessage;
-        private Func<string, bool> condition;
-        
+        #region Constructor
+
         /// <summary>
         /// Konstruktor.
         /// </summary>
@@ -28,28 +25,35 @@ namespace KinowySystemRezerwacji.view
             InitializeComponent();
         }
 
+        #endregion
+
+        #region Private fields and getters / setters / other
+
+        private bool shouldBeMasked = false;
+        private string placeHolder;
+        private bool shouldValidate = false;
+        private string errorMessage;
+        private Func<string, bool> condition;
+
         /// <summary>
-        /// Tekst wyświetlany w TextBoxie, gdy nie jest do niego wprowadzany tekst.
+        /// Metoda ustawiająca maskowanie wprowadzanego tekstu.
         /// </summary>
-        internal string PlaceHolder
+        /// <param name="value">Informacja o tym, czy maskować hasło</param>
+        internal void SetShouldBeMasked(bool value)
         {
-            get
-            {
-                return placeHolder;
-            }
-            set
-            {
-                placeHolder = value;
-                textBox1.ForeColor = Color.Gray;
-                textBox1.Text = placeHolder;
-            }
+            shouldBeMasked = true;
         }
 
         /// <summary>
-        /// Tekst wpisany do TextBoxa.
+        /// Metoda ustawiająca placeholder w TextBoxie.
         /// </summary>
-        public override string Text { get { return textBox1.Text; } }
-
+        /// <param name="value">Treść placeholdera</param>
+        internal void SetPlaceHolder(string value)
+        {
+            placeHolder = value;
+            textBox1.ForeColor = Color.Gray;
+            textBox1.Text = placeHolder;
+        }
 
         /// <summary>
         /// Metoda ustawiająca parametry walidacji pola tekstowego.
@@ -58,31 +62,32 @@ namespace KinowySystemRezerwacji.view
         /// <param name="condition">Warunek, jaki musi spełnić tekst, aby przejść walidację</param>
         internal void SetValidation(string errorMessage, Func<string, bool> condition)
         {
+            shouldValidate = true;
             this.errorMessage = errorMessage;
             this.condition = condition;
         }
-        
 
         /// <summary>
-        /// Metoda uruchamiająca ErrorProvidera obok TextBoxa.
+        /// Metoda włączająca / wyłączająca walidację dla TextBoxa.
         /// </summary>
-        /// <param name="message">Treść komunikatu</param>
-        internal void SetError(string message)
+        /// <param name="value">Wartość logiczna informująca, czy pole ma być walidowane</param>
+        internal void SetShouldValidate(bool value)
         {
-            errorProvider1.SetError(textBox1, message);
+            shouldValidate = value;
         }
 
         /// <summary>
-        /// Metoda ustawiająca maskowanie wprowadzanego tekstu.
+        /// Metoda zwracająca tekst wpisany do TextBoxa.
         /// </summary>
-        /// <param name="value">Informacja o tym, czy maskować hasło</param>
-        internal void SetTextMask(bool value)
+        /// <returns>Tekst wpisany do TextBoxa</returns>
+        internal string GetText()
         {
-            shouldBeMasked = true;
+            return textBox1.Text;
         }
-        
-        
 
+        /// <summary>
+        /// Metoda resetująca TextBoxa.
+        /// </summary>
         internal void SetEmpty()
         {
             errorProvider1.Clear();
@@ -90,6 +95,32 @@ namespace KinowySystemRezerwacji.view
             textBox1.Text = placeHolder;
             textBox1.ForeColor = Color.Gray;
         }
+
+        /// <summary>
+        /// Metoda walidująca pole tekstowe.
+        /// </summary>
+        /// <returns>Rezultat walidacji</returns>
+        internal bool ValidateAndGetResult()
+        {
+            if (condition == null)
+            {
+                return true;
+            }
+            else if (condition(textBox1.Text))
+            {
+                errorProvider1.SetError(textBox1, "");
+                return true;
+            }
+            else
+            {
+                errorProvider1.SetError(textBox1, errorMessage);
+                return false;
+            }
+        }
+
+        #endregion
+
+        #region Windows Forms event handlers
 
         private void ExtendedTextBox_Enter(object sender, EventArgs e)
         {
@@ -106,13 +137,9 @@ namespace KinowySystemRezerwacji.view
 
         private void ExtendedTextBox_Leave(object sender, EventArgs e)
         {
-            if (condition != null && condition(textBox1.Text))
+            if (shouldValidate)
             {
-                errorProvider1.SetError(textBox1, "");
-            }
-            if (condition != null && !condition(textBox1.Text))
-            {
-                errorProvider1.SetError(textBox1, errorMessage);
+                ValidateAndGetResult();
             }
             if (textBox1.Text == "")
             {
@@ -122,9 +149,6 @@ namespace KinowySystemRezerwacji.view
             }
         }
 
-        private void ExtendedTextBox_Load(object sender, EventArgs e)
-        {
-            textBox1.Text = placeHolder;
-        }
+        #endregion
     }
 }

--- a/KinowySystemRezerwacji/view/ExtendedTextBox.cs
+++ b/KinowySystemRezerwacji/view/ExtendedTextBox.cs
@@ -15,6 +15,11 @@ namespace KinowySystemRezerwacji.view
     /// </summary>
     internal partial class ExtendedTextBox : UserControl
     {
+        private bool shouldBeMasked = false;
+        private string placeHolder;
+        private string errorMessage;
+        private Func<string, bool> condition;
+        
         /// <summary>
         /// Konstruktor.
         /// </summary>
@@ -22,8 +27,6 @@ namespace KinowySystemRezerwacji.view
         {
             InitializeComponent();
         }
-
-        private string placeHolder;
 
         /// <summary>
         /// Tekst wyświetlany w TextBoxie, gdy nie jest do niego wprowadzany tekst.
@@ -45,17 +48,20 @@ namespace KinowySystemRezerwacji.view
         /// <summary>
         /// Tekst wpisany do TextBoxa.
         /// </summary>
-        public override string Text
+        public override string Text { get { return textBox1.Text; } }
+
+
+        /// <summary>
+        /// Metoda ustawiająca parametry walidacji pola tekstowego.
+        /// </summary>
+        /// <param name="errorMessage">Wiadomość do pokazania przy błędzie walidacji</param>
+        /// <param name="condition">Warunek, jaki musi spełnić tekst, aby przejść walidację</param>
+        internal void SetValidation(string errorMessage, Func<string, bool> condition)
         {
-            get
-            {
-                return textBox1.Text;
-            }
-            set
-            {
-                textBox1.Text = value;
-            }
+            this.errorMessage = errorMessage;
+            this.condition = condition;
         }
+        
 
         /// <summary>
         /// Metoda uruchamiająca ErrorProvidera obok TextBoxa.
@@ -74,8 +80,16 @@ namespace KinowySystemRezerwacji.view
         {
             shouldBeMasked = true;
         }
+        
+        
 
-        private bool shouldBeMasked = false;
+        internal void SetEmpty()
+        {
+            errorProvider1.Clear();
+            textBox1.PasswordChar = '\0';
+            textBox1.Text = placeHolder;
+            textBox1.ForeColor = Color.Gray;
+        }
 
         private void ExtendedTextBox_Enter(object sender, EventArgs e)
         {
@@ -92,6 +106,14 @@ namespace KinowySystemRezerwacji.view
 
         private void ExtendedTextBox_Leave(object sender, EventArgs e)
         {
+            if (condition != null && condition(textBox1.Text))
+            {
+                errorProvider1.SetError(textBox1, "");
+            }
+            if (condition != null && !condition(textBox1.Text))
+            {
+                errorProvider1.SetError(textBox1, errorMessage);
+            }
             if (textBox1.Text == "")
             {
                 textBox1.PasswordChar = '\0';

--- a/KinowySystemRezerwacji/view/ExtendedTextBox.cs
+++ b/KinowySystemRezerwacji/view/ExtendedTextBox.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Drawing;
+using System.Data;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace KinowySystemRezerwacji.view
+{
+    /// <summary>
+    /// Kontrolka zawierająca TextBoxa zawierającego PlaceHoldera oraz ErrorProvidera.
+    /// </summary>
+    internal partial class ExtendedTextBox : UserControl
+    {
+        /// <summary>
+        /// Konstruktor.
+        /// </summary>
+        public ExtendedTextBox()
+        {
+            InitializeComponent();
+        }
+
+        private string placeHolder;
+
+        /// <summary>
+        /// Tekst wyświetlany w TextBoxie, gdy nie jest do niego wprowadzany tekst.
+        /// </summary>
+        internal string PlaceHolder
+        {
+            get
+            {
+                return placeHolder;
+            }
+            set
+            {
+                placeHolder = value;
+                textBox1.ForeColor = Color.Gray;
+                textBox1.Text = placeHolder;
+            }
+        }
+
+        /// <summary>
+        /// Tekst wpisany do TextBoxa.
+        /// </summary>
+        public override string Text
+        {
+            get
+            {
+                return textBox1.Text;
+            }
+            set
+            {
+                textBox1.Text = value;
+            }
+        }
+
+        /// <summary>
+        /// Metoda uruchamiająca ErrorProvidera obok TextBoxa.
+        /// </summary>
+        /// <param name="message">Treść komunikatu</param>
+        internal void SetError(string message)
+        {
+            errorProvider1.SetError(textBox1, message);
+        }
+
+        /// <summary>
+        /// Metoda ustawiająca maskowanie wprowadzanego tekstu.
+        /// </summary>
+        /// <param name="value">Informacja o tym, czy maskować hasło</param>
+        internal void SetTextMask(bool value)
+        {
+            shouldBeMasked = true;
+        }
+
+        private bool shouldBeMasked = false;
+
+        private void ExtendedTextBox_Enter(object sender, EventArgs e)
+        {
+            if (textBox1.Text == placeHolder)
+            {
+                if (shouldBeMasked)
+                {
+                    textBox1.PasswordChar = '*';
+                }
+                textBox1.Text = "";
+                textBox1.ForeColor = Color.Empty;
+            }
+        }
+
+        private void ExtendedTextBox_Leave(object sender, EventArgs e)
+        {
+            if (textBox1.Text == "")
+            {
+                textBox1.PasswordChar = '\0';
+                textBox1.Text = placeHolder;
+                textBox1.ForeColor = Color.Gray;
+            }
+        }
+
+        private void ExtendedTextBox_Load(object sender, EventArgs e)
+        {
+            textBox1.Text = placeHolder;
+        }
+    }
+}

--- a/KinowySystemRezerwacji/view/ExtendedTextBox.resx
+++ b/KinowySystemRezerwacji/view/ExtendedTextBox.resx
@@ -1,0 +1,123 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <metadata name="errorProvider1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+</root>

--- a/KinowySystemRezerwacji/view/LoginForm.Designer.cs
+++ b/KinowySystemRezerwacji/view/LoginForm.Designer.cs
@@ -28,13 +28,117 @@
         /// </summary>
         private void InitializeComponent()
         {
+            this.titleLabel = new System.Windows.Forms.Label();
+            this.confirmLoginRegisterButton = new System.Windows.Forms.Button();
+            this.switchLoginRegisterButton = new System.Windows.Forms.Button();
+            this.usernameExtendedTextBox = new KinowySystemRezerwacji.view.ExtendedTextBox();
+            this.passwordExtendedTextBox = new KinowySystemRezerwacji.view.ExtendedTextBox();
+            this.firstNameExtendedTextBox = new KinowySystemRezerwacji.view.ExtendedTextBox();
+            this.lastNameExtendedTextBox = new KinowySystemRezerwacji.view.ExtendedTextBox();
+            this.emailExtendedTextBox = new KinowySystemRezerwacji.view.ExtendedTextBox();
             this.SuspendLayout();
+            // 
+            // titleLabel
+            // 
+            this.titleLabel.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.titleLabel.Font = new System.Drawing.Font("Microsoft Sans Serif", 20.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(238)));
+            this.titleLabel.Location = new System.Drawing.Point(13, 10);
+            this.titleLabel.Name = "titleLabel";
+            this.titleLabel.Size = new System.Drawing.Size(359, 57);
+            this.titleLabel.TabIndex = 0;
+            this.titleLabel.Text = "Logowanie";
+            this.titleLabel.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // confirmLoginRegisterButton
+            // 
+            this.confirmLoginRegisterButton.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.confirmLoginRegisterButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 14.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(238)));
+            this.confirmLoginRegisterButton.Location = new System.Drawing.Point(45, 275);
+            this.confirmLoginRegisterButton.Name = "confirmLoginRegisterButton";
+            this.confirmLoginRegisterButton.Size = new System.Drawing.Size(295, 40);
+            this.confirmLoginRegisterButton.TabIndex = 6;
+            this.confirmLoginRegisterButton.Text = "Zaloguj";
+            this.confirmLoginRegisterButton.UseVisualStyleBackColor = true;
+            this.confirmLoginRegisterButton.Click += new System.EventHandler(this.confirmLoginRegisterButton_Click);
+            // 
+            // switchLoginRegisterButton
+            // 
+            this.switchLoginRegisterButton.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.switchLoginRegisterButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 14.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(238)));
+            this.switchLoginRegisterButton.Location = new System.Drawing.Point(45, 409);
+            this.switchLoginRegisterButton.Name = "switchLoginRegisterButton";
+            this.switchLoginRegisterButton.Size = new System.Drawing.Size(295, 40);
+            this.switchLoginRegisterButton.TabIndex = 7;
+            this.switchLoginRegisterButton.Text = "Tryb rejestracji";
+            this.switchLoginRegisterButton.UseVisualStyleBackColor = true;
+            this.switchLoginRegisterButton.Click += new System.EventHandler(this.switchLoginRegisterButton_Click);
+            // 
+            // usernameExtendedTextBox
+            // 
+            this.usernameExtendedTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.usernameExtendedTextBox.Location = new System.Drawing.Point(12, 70);
+            this.usernameExtendedTextBox.Name = "usernameExtendedTextBox";
+            this.usernameExtendedTextBox.Size = new System.Drawing.Size(360, 35);
+            this.usernameExtendedTextBox.TabIndex = 0;
+            // 
+            // passwordExtendedTextBox
+            // 
+            this.passwordExtendedTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.passwordExtendedTextBox.Location = new System.Drawing.Point(12, 111);
+            this.passwordExtendedTextBox.Name = "passwordExtendedTextBox";
+            this.passwordExtendedTextBox.Size = new System.Drawing.Size(360, 35);
+            this.passwordExtendedTextBox.TabIndex = 1;
+            // 
+            // firstNameExtendedTextBox
+            // 
+            this.firstNameExtendedTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.firstNameExtendedTextBox.Location = new System.Drawing.Point(12, 152);
+            this.firstNameExtendedTextBox.Name = "firstNameExtendedTextBox";
+            this.firstNameExtendedTextBox.Size = new System.Drawing.Size(360, 35);
+            this.firstNameExtendedTextBox.TabIndex = 2;
+            this.firstNameExtendedTextBox.Visible = false;
+            // 
+            // lastNameExtendedTextBox
+            // 
+            this.lastNameExtendedTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.lastNameExtendedTextBox.Location = new System.Drawing.Point(12, 193);
+            this.lastNameExtendedTextBox.Name = "lastNameExtendedTextBox";
+            this.lastNameExtendedTextBox.Size = new System.Drawing.Size(360, 35);
+            this.lastNameExtendedTextBox.TabIndex = 3;
+            this.lastNameExtendedTextBox.Visible = false;
+            // 
+            // emailExtendedTextBox
+            // 
+            this.emailExtendedTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.emailExtendedTextBox.Location = new System.Drawing.Point(12, 234);
+            this.emailExtendedTextBox.Name = "emailExtendedTextBox";
+            this.emailExtendedTextBox.Size = new System.Drawing.Size(360, 35);
+            this.emailExtendedTextBox.TabIndex = 4;
+            this.emailExtendedTextBox.Visible = false;
             // 
             // LoginForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(800, 450);
+            this.ClientSize = new System.Drawing.Size(384, 461);
+            this.Controls.Add(this.emailExtendedTextBox);
+            this.Controls.Add(this.lastNameExtendedTextBox);
+            this.Controls.Add(this.firstNameExtendedTextBox);
+            this.Controls.Add(this.passwordExtendedTextBox);
+            this.Controls.Add(this.usernameExtendedTextBox);
+            this.Controls.Add(this.switchLoginRegisterButton);
+            this.Controls.Add(this.confirmLoginRegisterButton);
+            this.Controls.Add(this.titleLabel);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
+            this.MaximizeBox = false;
             this.Name = "LoginForm";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             this.Text = "Logowanie do systemu";
@@ -43,6 +147,15 @@
         }
 
         #endregion
+
+        private System.Windows.Forms.Label titleLabel;
+        private System.Windows.Forms.Button confirmLoginRegisterButton;
+        private System.Windows.Forms.Button switchLoginRegisterButton;
+        private ExtendedTextBox usernameExtendedTextBox;
+        private ExtendedTextBox passwordExtendedTextBox;
+        private ExtendedTextBox firstNameExtendedTextBox;
+        private ExtendedTextBox lastNameExtendedTextBox;
+        private ExtendedTextBox emailExtendedTextBox;
     }
 }
 

--- a/KinowySystemRezerwacji/view/LoginForm.Designer.cs
+++ b/KinowySystemRezerwacji/view/LoginForm.Designer.cs
@@ -71,7 +71,7 @@
             this.switchLoginRegisterButton.Location = new System.Drawing.Point(45, 409);
             this.switchLoginRegisterButton.Name = "switchLoginRegisterButton";
             this.switchLoginRegisterButton.Size = new System.Drawing.Size(295, 40);
-            this.switchLoginRegisterButton.TabIndex = 7;
+            this.switchLoginRegisterButton.TabIndex = 0;
             this.switchLoginRegisterButton.Text = "Tryb rejestracji";
             this.switchLoginRegisterButton.UseVisualStyleBackColor = true;
             this.switchLoginRegisterButton.Click += new System.EventHandler(this.switchLoginRegisterButton_Click);
@@ -83,7 +83,7 @@
             this.usernameExtendedTextBox.Location = new System.Drawing.Point(12, 70);
             this.usernameExtendedTextBox.Name = "usernameExtendedTextBox";
             this.usernameExtendedTextBox.Size = new System.Drawing.Size(360, 35);
-            this.usernameExtendedTextBox.TabIndex = 0;
+            this.usernameExtendedTextBox.TabIndex = 1;
             // 
             // passwordExtendedTextBox
             // 
@@ -92,7 +92,7 @@
             this.passwordExtendedTextBox.Location = new System.Drawing.Point(12, 111);
             this.passwordExtendedTextBox.Name = "passwordExtendedTextBox";
             this.passwordExtendedTextBox.Size = new System.Drawing.Size(360, 35);
-            this.passwordExtendedTextBox.TabIndex = 1;
+            this.passwordExtendedTextBox.TabIndex = 2;
             // 
             // firstNameExtendedTextBox
             // 
@@ -101,7 +101,7 @@
             this.firstNameExtendedTextBox.Location = new System.Drawing.Point(12, 152);
             this.firstNameExtendedTextBox.Name = "firstNameExtendedTextBox";
             this.firstNameExtendedTextBox.Size = new System.Drawing.Size(360, 35);
-            this.firstNameExtendedTextBox.TabIndex = 2;
+            this.firstNameExtendedTextBox.TabIndex = 3;
             this.firstNameExtendedTextBox.Visible = false;
             // 
             // lastNameExtendedTextBox
@@ -111,7 +111,7 @@
             this.lastNameExtendedTextBox.Location = new System.Drawing.Point(12, 193);
             this.lastNameExtendedTextBox.Name = "lastNameExtendedTextBox";
             this.lastNameExtendedTextBox.Size = new System.Drawing.Size(360, 35);
-            this.lastNameExtendedTextBox.TabIndex = 3;
+            this.lastNameExtendedTextBox.TabIndex = 4;
             this.lastNameExtendedTextBox.Visible = false;
             // 
             // emailExtendedTextBox
@@ -121,7 +121,7 @@
             this.emailExtendedTextBox.Location = new System.Drawing.Point(12, 234);
             this.emailExtendedTextBox.Name = "emailExtendedTextBox";
             this.emailExtendedTextBox.Size = new System.Drawing.Size(360, 35);
-            this.emailExtendedTextBox.TabIndex = 4;
+            this.emailExtendedTextBox.TabIndex = 5;
             this.emailExtendedTextBox.Visible = false;
             // 
             // LoginForm

--- a/KinowySystemRezerwacji/view/LoginForm.cs
+++ b/KinowySystemRezerwacji/view/LoginForm.cs
@@ -7,6 +7,8 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Forms;
+using System.Text.RegularExpressions;
+using System.ComponentModel.DataAnnotations;
 using KinowySystemRezerwacji.dto;
 
 namespace KinowySystemRezerwacji.view
@@ -18,7 +20,23 @@ namespace KinowySystemRezerwacji.view
     {
         #region Singleton elements
 
+        /// <summary>
+        /// Instancja klasy.
+        /// </summary>
         private static LoginForm instance = null;
+
+        /// <summary>
+        /// Metoda tworząca instancję klasy, jeśli ta jeszcze nie istnieje.
+        /// </summary>
+        /// <returns>Nowo utworzona lub wcześniej istniejąca instancja klasy</returns>
+        internal static LoginForm GetInstance()
+        {
+            if (instance == null)
+            {
+                instance = new LoginForm();
+            }
+            return instance;
+        }
 
         /// <summary>
         /// Konstruktor, lol.
@@ -27,25 +45,25 @@ namespace KinowySystemRezerwacji.view
         {
             InitializeComponent();
             passwordExtendedTextBox.SetTextMask(true);
+
             usernameExtendedTextBox.PlaceHolder = "Nazwa użytkownika";
             passwordExtendedTextBox.PlaceHolder = "Hasło";
             firstNameExtendedTextBox.PlaceHolder = "Imię";
             lastNameExtendedTextBox.PlaceHolder = "Nazwisko";
             emailExtendedTextBox.PlaceHolder = "E-mail";
-            confirmLoginRegisterButton.Top = 152;
-        }
 
-        /// <summary>
-        /// Metoda tworząca obiekt ekranu logowania, jeśli ten jeszcze nie istnieje.
-        /// </summary>
-        /// <returns>Obiekt ekranu logowania</returns>
-        internal static LoginForm GetInstance()
-        {
-            if (instance == null)
-            {
-                instance = new LoginForm();
-            }
-            return instance;
+            usernameExtendedTextBox.SetValidation("Nazwa użytkownika musi zawierać co najmniej 8 znaków", 
+                (string text) => text.Length >= 8 && !text.Contains(" "));
+            passwordExtendedTextBox.SetValidation("Hasło musi zawierać co najmniej 8 znaków, co najmniej jedną cyfrę i co najmniej jedną wielką literę", 
+                (string text) => !new Regex(@"^(.{0,7}|[^0-9]*|[^A-Z])$").Match(text).Success);
+            firstNameExtendedTextBox.SetValidation("Imię musi rozpoczynać się z wielkiej litery", 
+                (string text) => text.Length > 0 && text.First() == text.ToUpper().First());
+            lastNameExtendedTextBox.SetValidation("Nazwisko musi rozpoczynać się z wielkiej litery", 
+                (string text) => text.Length > 0 && text.First() == text.ToUpper().First());
+            emailExtendedTextBox.SetValidation("Podany e-mail jest nieprawidłowy", 
+                (string text) => new EmailAddressAttribute().IsValid(text));
+
+            confirmLoginRegisterButton.Top = 152;
         }
 
         #endregion
@@ -59,11 +77,11 @@ namespace KinowySystemRezerwacji.view
 
         private void ResetTextFields()
         {
-            //usernameExtendedTextBox.Text = "";
-            //passwordExtendedTextBox.Text = "";
-            //firstNameExtendedTextBox.Text = "";
-            //lastNameExtendedTextBox.Text = "";
-            //emailExtendedTextBox.Text = "";
+            usernameExtendedTextBox.SetEmpty();
+            passwordExtendedTextBox.SetEmpty();
+            firstNameExtendedTextBox.SetEmpty();
+            lastNameExtendedTextBox.SetEmpty();
+            emailExtendedTextBox.SetEmpty();
         }
 
         private void confirmLoginRegisterButton_Click(object sender, EventArgs e)

--- a/KinowySystemRezerwacji/view/LoginForm.cs
+++ b/KinowySystemRezerwacji/view/LoginForm.cs
@@ -18,7 +18,7 @@ namespace KinowySystemRezerwacji.view
     /// </summary>
     internal partial class LoginForm : Form
     {
-        #region Singleton elements
+        #region Static members
 
         /// <summary>
         /// Instancja klasy.
@@ -38,19 +38,41 @@ namespace KinowySystemRezerwacji.view
             return instance;
         }
 
+        #endregion
+
+        #region Events
+
+        public event Action<RegisterRequest> RequestRegister;
+        public event Action<string, string> RequestLogIn;
+
+        #endregion
+
+        #region Mode
+
+        /// <summary>
+        /// Enum określający wybrany tryb - logowania lub rejestracji.
+        /// </summary>
+        private enum Mode { LOGIN, REGISTER };
+
+        private Mode mode = Mode.LOGIN;
+
+        #endregion
+
+        #region Konstruktor
+
         /// <summary>
         /// Konstruktor, lol.
         /// </summary>
         private LoginForm()
         {
             InitializeComponent();
-            passwordExtendedTextBox.SetTextMask(true);
+            passwordExtendedTextBox.SetShouldBeMasked(true);
 
-            usernameExtendedTextBox.PlaceHolder = "Nazwa użytkownika";
-            passwordExtendedTextBox.PlaceHolder = "Hasło";
-            firstNameExtendedTextBox.PlaceHolder = "Imię";
-            lastNameExtendedTextBox.PlaceHolder = "Nazwisko";
-            emailExtendedTextBox.PlaceHolder = "E-mail";
+            usernameExtendedTextBox.SetPlaceHolder("Nazwa użytkownika");
+            passwordExtendedTextBox.SetPlaceHolder("Hasło");
+            firstNameExtendedTextBox.SetPlaceHolder("Imię");
+            lastNameExtendedTextBox.SetPlaceHolder("Nazwisko");
+            emailExtendedTextBox.SetPlaceHolder("E-mail");
 
             usernameExtendedTextBox.SetValidation("Nazwa użytkownika musi zawierać co najmniej 8 znaków", 
                 (string text) => text.Length >= 8 && !text.Contains(" "));
@@ -64,43 +86,36 @@ namespace KinowySystemRezerwacji.view
                 (string text) => new EmailAddressAttribute().IsValid(text));
 
             confirmLoginRegisterButton.Top = 152;
+
+            usernameExtendedTextBox.SetShouldValidate(false);
+            passwordExtendedTextBox.SetShouldValidate(false);
         }
 
         #endregion
 
-        public event Action<RegisterRequest> RequestRegister;
-        public event Action<string, string> RequestLogIn;
-
-        private enum Mode { LOGIN, REGISTER };
-
-        private Mode mode = Mode.LOGIN;
-
-        private void ResetTextFields()
-        {
-            usernameExtendedTextBox.SetEmpty();
-            passwordExtendedTextBox.SetEmpty();
-            firstNameExtendedTextBox.SetEmpty();
-            lastNameExtendedTextBox.SetEmpty();
-            emailExtendedTextBox.SetEmpty();
-        }
+        #region Windows Forms event handlers
 
         private void confirmLoginRegisterButton_Click(object sender, EventArgs e)
         {
             if (mode == Mode.LOGIN)
             {
-                RequestLogIn?.Invoke(usernameExtendedTextBox.Text, passwordExtendedTextBox.Text);
+                RequestLogIn?.Invoke(usernameExtendedTextBox.GetText(), passwordExtendedTextBox.GetText());
             }
-            if (mode == Mode.REGISTER)
+            else if (mode == Mode.REGISTER && usernameExtendedTextBox.ValidateAndGetResult() && passwordExtendedTextBox.ValidateAndGetResult()  && firstNameExtendedTextBox.ValidateAndGetResult() && lastNameExtendedTextBox.ValidateAndGetResult() && emailExtendedTextBox.ValidateAndGetResult())
             {
                 RegisterRequest request = new RegisterRequest
                 {
-                    Username = usernameExtendedTextBox.Text,
-                    Password = passwordExtendedTextBox.Text,
-                    FirstName = firstNameExtendedTextBox.Text,
-                    LastName = lastNameExtendedTextBox.Text,
-                    Email = emailExtendedTextBox.Text
+                    Username = usernameExtendedTextBox.GetText(),
+                    Password = passwordExtendedTextBox.GetText(),
+                    FirstName = firstNameExtendedTextBox.GetText(),
+                    LastName = lastNameExtendedTextBox.GetText(),
+                    Email = emailExtendedTextBox.GetText()
                 };
                 RequestRegister?.Invoke(request);
+            }
+            else
+            {
+                MessageBox.Show("Wpisano niepoprawne dane", "Błąd", MessageBoxButtons.OK);
             }
         }
 
@@ -116,7 +131,9 @@ namespace KinowySystemRezerwacji.view
                 lastNameExtendedTextBox.Visible = true;
                 emailExtendedTextBox.Visible = true;
                 confirmLoginRegisterButton.Top = 276;
-                ResetTextFields();
+                usernameExtendedTextBox.SetShouldValidate(true);
+                passwordExtendedTextBox.SetShouldValidate(true);
+
             }
             else if (mode == Mode.REGISTER)
             {
@@ -128,8 +145,17 @@ namespace KinowySystemRezerwacji.view
                 lastNameExtendedTextBox.Visible = false;
                 emailExtendedTextBox.Visible = false;
                 confirmLoginRegisterButton.Top = 152;
-                ResetTextFields();
+                usernameExtendedTextBox.SetShouldValidate(false);
+                passwordExtendedTextBox.SetShouldValidate(false);
             }
+
+            usernameExtendedTextBox.SetEmpty();
+            passwordExtendedTextBox.SetEmpty();
+            firstNameExtendedTextBox.SetEmpty();
+            lastNameExtendedTextBox.SetEmpty();
+            emailExtendedTextBox.SetEmpty();
         }
+
+        #endregion
     }
 }

--- a/KinowySystemRezerwacji/view/LoginForm.cs
+++ b/KinowySystemRezerwacji/view/LoginForm.cs
@@ -19,9 +19,20 @@ namespace KinowySystemRezerwacji.view
         #region Singleton elements
 
         private static LoginForm instance = null;
+
+        /// <summary>
+        /// Konstruktor, lol.
+        /// </summary>
         private LoginForm()
         {
             InitializeComponent();
+            passwordExtendedTextBox.SetTextMask(true);
+            usernameExtendedTextBox.PlaceHolder = "Nazwa użytkownika";
+            passwordExtendedTextBox.PlaceHolder = "Hasło";
+            firstNameExtendedTextBox.PlaceHolder = "Imię";
+            lastNameExtendedTextBox.PlaceHolder = "Nazwisko";
+            emailExtendedTextBox.PlaceHolder = "E-mail";
+            confirmLoginRegisterButton.Top = 152;
         }
 
         /// <summary>
@@ -41,5 +52,66 @@ namespace KinowySystemRezerwacji.view
 
         public event Action<RegisterRequest> RequestRegister;
         public event Action<string, string> RequestLogIn;
+
+        private enum Mode { LOGIN, REGISTER };
+
+        private Mode mode = Mode.LOGIN;
+
+        private void ResetTextFields()
+        {
+            //usernameExtendedTextBox.Text = "";
+            //passwordExtendedTextBox.Text = "";
+            //firstNameExtendedTextBox.Text = "";
+            //lastNameExtendedTextBox.Text = "";
+            //emailExtendedTextBox.Text = "";
+        }
+
+        private void confirmLoginRegisterButton_Click(object sender, EventArgs e)
+        {
+            if (mode == Mode.LOGIN)
+            {
+                RequestLogIn?.Invoke(usernameExtendedTextBox.Text, passwordExtendedTextBox.Text);
+            }
+            if (mode == Mode.REGISTER)
+            {
+                RegisterRequest request = new RegisterRequest
+                {
+                    Username = usernameExtendedTextBox.Text,
+                    Password = passwordExtendedTextBox.Text,
+                    FirstName = firstNameExtendedTextBox.Text,
+                    LastName = lastNameExtendedTextBox.Text,
+                    Email = emailExtendedTextBox.Text
+                };
+                RequestRegister?.Invoke(request);
+            }
+        }
+
+        private void switchLoginRegisterButton_Click(object sender, EventArgs e)
+        {
+            if (mode == Mode.LOGIN)
+            {
+                mode = Mode.REGISTER;
+                titleLabel.Text = "Rejestracja";
+                confirmLoginRegisterButton.Text = "Zarejestruj";
+                switchLoginRegisterButton.Text = "Tryb logowania";
+                firstNameExtendedTextBox.Visible = true;
+                lastNameExtendedTextBox.Visible = true;
+                emailExtendedTextBox.Visible = true;
+                confirmLoginRegisterButton.Top = 276;
+                ResetTextFields();
+            }
+            else if (mode == Mode.REGISTER)
+            {
+                mode = Mode.LOGIN;
+                titleLabel.Text = "Logowanie";
+                confirmLoginRegisterButton.Text = "Zaloguj";
+                switchLoginRegisterButton.Text = "Tryb rejestracji";
+                firstNameExtendedTextBox.Visible = false;
+                lastNameExtendedTextBox.Visible = false;
+                emailExtendedTextBox.Visible = false;
+                confirmLoginRegisterButton.Top = 152;
+                ResetTextFields();
+            }
+        }
     }
 }

--- a/KinowySystemRezerwacji/view/ViewManager.cs
+++ b/KinowySystemRezerwacji/view/ViewManager.cs
@@ -90,7 +90,7 @@ namespace KinowySystemRezerwacji.view
 
         public void ShowMessage(bool success, string message)
         {
-            MessageBox.Show(message, success ? "Message" : "Error", MessageBoxButtons.OK);
+            MessageBox.Show(message, success ? "Komunikat" : "Błąd", MessageBoxButtons.OK);
         }
 
         public Form GetActiveForm()

--- a/README.md
+++ b/README.md
@@ -11,5 +11,6 @@ System może zostać w przyszłości rozbudowany o następujące funkcjonalnośc
 - anulowanie dokonanych rezerwacji
 - dodawanie filmów i seansów (dla administratorów)
 - obsługa wielu sal kinowych
+- filtrowanie filmów zgodnie z wiekiem użytkownika
 
 Dostęp do systemu jest zabezpieczony mechanizmem logowania.

--- a/create-database.sql
+++ b/create-database.sql
@@ -13,7 +13,7 @@ default character set utf8 collate utf8_unicode_ci;
 CREATE TABLE Uzytkownicy(
 id int not null auto_increment,
 nazwa_uzytkownika char(14) not null,
-ukryte_haslo char(50),
+ukryte_haslo char(50) not null,
 imie char(20) not null,
 nazwisko char(30) not null,
 email char(30) not null,


### PR DESCRIPTION
Przy rejestracji celowo nie utworzyłem pola na datę urodzenia nowego użytkownika - to by było dość czasochłonne, a nie jest nam potrzebne do wykonania założeń. Data urodzenia przydałaby się przy wybieraniu filmów, aby filtrować je po możliwym wieku, ale nevermind :P Natomiast robiąc takie założenie (niezapisywanie daty urodzenia) musiałem dopuścić nulle w skrypcie tworzącym bazę danych, a tam - już były jako nulle xD I hasło też dopuszczało nulle, to zmieniłem przy haśle przy okazji, żeby jednak tych nulli nie dopuszczało. Uzupełniłem też dokumentację o opcjonalny feature - właśnie tą kontrolę rodzicielską.

Komunikaty do użytkownika są po polsku, ale to chyba akurat pasuje, skoro bazę danych mamy po polsku.

@kamil-rusin przetestuj proszę, czy na pewno wszystko działa.