### PR TITLE
Zaktualizowanie warunków walidacji

### DIFF
--- a/KinowySystemRezerwacji/view/LoginForm.cs
+++ b/KinowySystemRezerwacji/view/LoginForm.cs
@@ -74,7 +74,7 @@ namespace KinowySystemRezerwacji.view
             lastNameExtendedTextBox.SetPlaceHolder("Nazwisko");
             emailExtendedTextBox.SetPlaceHolder("E-mail");
 
-            usernameExtendedTextBox.SetValidation("Nazwa użytkownika musi zawierać od 8 do 14 znaków", 
+            usernameExtendedTextBox.SetValidation("Nazwa użytkownika musi zawierać od 8 do 14 znaków oraz nie może zawierać znaku spacji", 
                 (string text) => text.Length >= 8 && text.Length <= 14 && !text.Contains(" "));
             passwordExtendedTextBox.SetValidation("Hasło musi zawierać co najmniej 8 znaków, co najmniej jedną cyfrę i co najmniej jedną wielką literę", 
                 (string text) => !new Regex(@"^(.{0,7}|[^0-9]*|[^A-Z])$").Match(text).Success);

--- a/KinowySystemRezerwacji/view/LoginForm.cs
+++ b/KinowySystemRezerwacji/view/LoginForm.cs
@@ -74,16 +74,16 @@ namespace KinowySystemRezerwacji.view
             lastNameExtendedTextBox.SetPlaceHolder("Nazwisko");
             emailExtendedTextBox.SetPlaceHolder("E-mail");
 
-            usernameExtendedTextBox.SetValidation("Nazwa użytkownika musi zawierać co najmniej 8 znaków", 
-                (string text) => text.Length >= 8 && !text.Contains(" "));
+            usernameExtendedTextBox.SetValidation("Nazwa użytkownika musi zawierać od 8 do 14 znaków", 
+                (string text) => text.Length >= 8 && text.Length <= 14 && !text.Contains(" "));
             passwordExtendedTextBox.SetValidation("Hasło musi zawierać co najmniej 8 znaków, co najmniej jedną cyfrę i co najmniej jedną wielką literę", 
                 (string text) => !new Regex(@"^(.{0,7}|[^0-9]*|[^A-Z])$").Match(text).Success);
-            firstNameExtendedTextBox.SetValidation("Imię musi rozpoczynać się z wielkiej litery", 
-                (string text) => text.Length > 0 && text.First() == text.ToUpper().First());
-            lastNameExtendedTextBox.SetValidation("Nazwisko musi rozpoczynać się z wielkiej litery", 
-                (string text) => text.Length > 0 && text.First() == text.ToUpper().First());
+            firstNameExtendedTextBox.SetValidation("Imię musi rozpoczynać się z wielkiej litery oraz zawierać co najwyżej 20 znaków", 
+                (string text) => text.Length > 0 && text.Length <= 20 && text.Length <= 20 && text.First() == text.ToUpper().First());
+            lastNameExtendedTextBox.SetValidation("Nazwisko musi rozpoczynać się z wielkiej litery oraz zawierać co najwyżej 30 znaków", 
+                (string text) => text.Length > 0 && text.Length <= 30 && text.First() == text.ToUpper().First());
             emailExtendedTextBox.SetValidation("Podany e-mail jest nieprawidłowy", 
-                (string text) => new EmailAddressAttribute().IsValid(text));
+                (string text) => text.Length <= 30 && new EmailAddressAttribute().IsValid(text));
 
             confirmLoginRegisterButton.Top = 152;
 


### PR DESCRIPTION
Jako że w bazie danych mamy górne ograniczenia na poszczególne pola dotyczące użytkownika, to można by nie pozwolić użytkownikowi wpisania danych dłuższych niż jest to możliwe do zapisania w bazie danych. Modyfikacja rozszerza wcześniejszą walidację sprawdzając, czy długość wpisanych danych mieści się w zakresie.

O ile w przypadku danych takich, jak login czy email, nie miałem żadnych wątpliwości, o tyle w przypadku imienia i nazwiska już tak. Bo czy użytkownik rzeczywiście powinien widzieć komunikat "imię powinno zawierać co najwyżej 20 znaków"? Brzmi dziwnie, ale z drugiej strony, jeśli ktoś by wpisał dłuższe, mógłby być niemile zaskoczony na widok, że jego imię zostało skrócone.

Przypadki skrajne, ale można by się zastanowić